### PR TITLE
Add new axis options to ads7846-overlay.dts

### DIFF
--- a/arch/arm/boot/dts/overlays/ads7846-overlay.dts
+++ b/arch/arm/boot/dts/overlays/ads7846-overlay.dts
@@ -85,5 +85,9 @@
 		pmin =   <&ads7846>,"ti,pressure-min;0";
 		pmax =   <&ads7846>,"ti,pressure-max;0";
 		xohms =  <&ads7846>,"ti,x-plate-ohms;0";
+
+		touchscreen-inverted-x = <&ads7846>,"touchscreen-inverted-x?";
+		touchscreen-inverted-y = <&ads7846>,"touchscreen-inverted-y?";
+		touchscreen-swapped-x-y = <&ads7846>,"touchscreen-swapped-x-y?";
 	};
 };


### PR DESCRIPTION
I've used the option names found in rpi-ft5406-overlay.dts.

I have.a 3.5 inch display from [uctronics](https://github.com/UCTRONICS/UCTRONICS_LCD35_HDMI_RPI/blob/master/Raspbian/usr/ucts_0.dts) that needs the axes swapped and the y axis inverted. 

I've successfully tried it on a fresh install of the 17.1-20200813 rpi4 release and with a kernel built against the head of this repo using a /boot/config.txt that looks like:

```
dtoverlay=ads7846,cs=0,penirq=25,penirq_pull=2
dtparam=speed=50000
dtparam=pmax=255
dtparam=xohms=60
dtparam=xmin=200
dtparam=xmax=3901
dtparam=ymin=257
dtparam=ymax=3739
#dtparam=touchscreen-inverted-x
dtparam=touchscreen-inverted-y
dtparam=touchscreen-swapped-x-y
```